### PR TITLE
Renamed Indian state to Odisha

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -2133,7 +2133,7 @@ function give_get_indian_states_list() {
 		'ML' => 'Meghalaya',
 		'MZ' => 'Mizoram',
 		'NL' => 'Nagaland',
-		'OR' => 'Orissa',
+		'OR' => 'Odisha',
 		'PB' => 'Punjab',
 		'RJ' => 'Rajasthan',
 		'SK' => 'Sikkim',


### PR DESCRIPTION
Renamed the Indian state Orissa to Odisha, [source](https://en.wikipedia.org/wiki/Odisha#Etymology)